### PR TITLE
disable conda in ci test 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           - "--pileup_count count"
           - "--denovo"
         profile:
-          - "conda"
+          #- "conda"
           - "docker"
           - "singularity"
         test_name:


### PR DESCRIPTION
modules `dorado` and `pb-CpG-tools' are not supported on conda. 
